### PR TITLE
wrong path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ How to install it?
         Add the following lines in your ``deps`` file::
 
             [SaadTaziGChartBundle]
-                git=git://github.com/SaadTazi/SaadTaziGChartBundle.git
-                target=/bundles/SaadTazi/Bundle/GChartBundle
+                git=git://github.com/saadtazi/SaadTaziGChartBundle.git
+                target=/bundles/SaadTazi/GChartBundle
 
         Run the vendors script:
 
@@ -41,7 +41,7 @@ How to install it?
 
       * Using git submodules.
 
-            $ git submodule add git://github.com/SaadTazi/SaadTaziGChartBundle.git vendor/bundles/SaadTazi/Bundle/GChartBundle
+            $ git submodule add git://github.com/saadtazi/SaadTaziGChartBundle.git vendor/bundles/SaadTazi/GChartBundle
 
   2. Add the SaadTazi namespace to your autoloader:
 
@@ -63,7 +63,7 @@ How to install it?
           {
               return array(
                   // ...
-                  new SaadTazi\Bundle\GChartBundle\SaadTaziGChartBundle(),
+                  new SaadTazi\GChartBundle\SaadTaziGChartBundle(),
                   // ...
               );
           }


### PR DESCRIPTION
hello SaadTazi,
I tried to install the bundle according to your readme and found a small bug.
It seams you changed your GitHub Url from ".../SaadTazi/.." to ".../saadtazi/.." and the installation directory from vendor/bundles/SaadTazi/Bundle/GChartBundle to vendor/bundles/SaadTazi/GChartBundle so I fixed the readme file
