### PR TITLE
Changed session.flash to new session.flashbag

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -16,11 +16,11 @@
                 <h1>GChartBundle Demo</h2>
             </header>
 
-            {% if app.session.flash('notice') %}
+            {% for msg in app.session.flashbag.get('notice') %}
                 <div class="flash-message">
-                    <em>Notice</em>: {{ app.session.flash('notice') }}
+                    <em>Notice</em>: {{ msg }}
                 </div>
-            {% endif %}
+            {% endfor %}
 
             
 


### PR DESCRIPTION
In newest version of Symfony 2, app.session.flash is throwing 500 error when executing demo view. Changed to new session.flashbag
