### PR TITLE
Feature new gcharts loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 What is it?
 ===========
-This is a super simple Bundle that facilitate the usage of [Google Chart Tool](http://code.google.com/apis/chart/interactive/docs/index.html), [Google Chart Image API](http://code.google.com/apis/chart/image/) and [Google Infographics](http://code.google.com/apis/chart/infographics/).
+This is a super simple Bundle that facilitates the usage of [Google Chart Tool](https://developers.google.com/chart/), [Google Chart Image API](http://code.google.com/apis/chart/image/) and [Google Infographics](http://code.google.com/apis/chart/infographics/).
 
 It allows to render:
 
@@ -17,7 +17,7 @@ It allows to render:
   * Map tree
   * Dynamic Icons
 
-Added (special recommendations are bellow):
+Added (special recommendations are below):
 
   * Calendar
   * Bubble Chart
@@ -48,7 +48,7 @@ How to install it?
 ------------------
 
 Thanks to [AaronDDM](http://example.com/ "AaronDDM"), you can use
-[composer](http://packagist.org/packages/saad-tazi/g-chart-bundle "composer") to instlall the bundle.
+[composer](http://packagist.org/packages/saad-tazi/g-chart-bundle "composer") to install the bundle.
 ```
 composer require saad-tazi/g-chart-bundle
 ```
@@ -115,8 +115,8 @@ Don't forget to include the required javascript in your layout, for example:
 
 ```
         <script type="text/javascript">
-            // adds the package you need
-            google.load("visualization", "1", {packages:["corechart", 'table', 'gauge']});
+            // adds the package you need. See https://developers.google.com/chart/interactive/docs/basic_load_libs
+            google.charts.load('current', {packages:["corechart", 'table', 'gauge']});
         </script>
 ```
 

--- a/Resources/views/Demo/demo.html.twig
+++ b/Resources/views/Demo/demo.html.twig
@@ -5,7 +5,6 @@
 
 <div id="myTableTreeMap" style="width: 1100px;height:500px;">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_treemap(dt10, 'myTableTreeMap', 1100, 500, '', {
             'minColor': '#f00',
             'midColor': '#ddd',
@@ -13,7 +12,6 @@ $(function() {
             'headerHeight': 15,
             'fontColor': 'black',
             'showScale': true}) }}
-});
 </script>
 <hr/>
 <h2>QR Code Demo</h2>
@@ -26,131 +24,101 @@ $(function() {
 
 <div id="chart1">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_pie_chart(dataTable1, 'chart1', 400, 200, 'coucou') }}
-});
 </script>
 <hr/>
 
 <div id="chart2">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_column_chart(dataTable2, 'chart2', 400, 200, 'coucou') }}
-});
 </script>
 <hr/>
 
 <div id="chart22">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_column_chart(dataTable8, 'chart22', 400, 200, 'coucou chart 8') }}
-});
-</script>   
+</script>
 <hr/>
 
 <h2>linechart with options</h2>
 <div id="chart3">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_line_chart(dataTable2, 'chart3', 400, 200, 'coucou',{'hAxis': {'title': 'Hello',  'titleTextStyle': {'color': '#FF0000'}}}) }}
-});
 </script>
 <hr/>
 dataTable2
 <div id="chart4">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_bar_chart(dataTable2, 'chart4', 400, 200, 'coucou') }}
-});
 </script>
 <hr/>
 dataTable5
 <div id="chartfromMatrix5">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_bar_chart(dataTable5, 'chartfromMatrix5', 400, 200, 'from table5') }}
-});
 </script>
 <hr/>
 
 dataTable6
 <div id="chartfromMatrix6">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_bar_chart(dataTable6, 'chartfromMatrix6', 400, 200, 'from table6') }}
-});
 </script>
 <hr/>
 
 dataTable2
 <div id="chart5">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_area_chart(dataTable2, 'chart5', 400, 200, 'coucou') }}
-});
 </script>
 <hr/>
 
 dataTable4
 <div id="chart6">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_scatter_chart(dataTable4, 'chart6', 400, 200, 'coucou', 'x label', 'y label') }}
-});
 </script>
 <hr/>
 
 dataTable2
 <div id="chart7">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_combo_chart(dataTable2, 'chart7', 400, 200, 'line', 'combo', {'series': {1: {'type': 'bars'} } }) }}
-});
 </script>
 <hr/>
 
 dataTable1
 <div id="gauge1">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_gauge(dataTable1, 'gauge1', 400, 200, 'coucou') }}
-});
 </script>
 <hr/>
 
 dataTable2
 <div id="table1">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_table(dataTable2, 'table1') }}
-});
 </script>
 <hr/>
 
 dataTable7
 <div id="chartfromMatrix7">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_table(dataTable7, 'chartfromMatrix7', 400, 200, 'from table7') }}
-});
 </script>
 <hr/>
 
 dt
 <div id="myTable1">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_table(dt, 'myTable1') }}
-});
 </script>
 <hr/>
 
 dt9
 <div id="myTableCandleStick">&nbsp;</div>
 <script>
-$(function() {
 {{ gchart_candlestick_chart(dt9, 'myTableCandleStick', 400, 200) }}
-});
 </script>
 <hr/>
 

--- a/Resources/views/Demo/demo2.html.twig
+++ b/Resources/views/Demo/demo2.html.twig
@@ -4,9 +4,7 @@
 
 <div id="myTable1">&nbsp;</div>
 <script>
-$(function() {
     {{ gchart_table(dt, 'myTable1') }}
-});
 </script>
         
 {% endblock %}

--- a/Resources/views/Demo/demo3.html.twig
+++ b/Resources/views/Demo/demo3.html.twig
@@ -4,9 +4,7 @@
 
 <div id="myArea1">&nbsp;</div>
 <script>
-$(function() {
     {{ gchart_area_chart(dt, 'myArea1', 500, 400, 'coucou') }}
-});
 </script>
 
 {% endblock %}

--- a/Resources/views/chart/visualizationChart.html.twig
+++ b/Resources/views/chart/visualizationChart.html.twig
@@ -1,3 +1,5 @@
+function drawGoogleChart_{{ id }} () {
+
 {% if chartType == 'Calendar' or chartType == 'Timeline' %}
     {% set data = data | json_encode | replace({"\"new Date[[[": 'new Date(', "new Date\"": ""}) | replace({"]]]\"": ')', "]]]\"": ")"}) | replace({"id\":\"role_tooltip": "role\": \"tooltip", "id\":\"role_tooltip": "role\": \"tooltip"}) %}
 {% elseif chartType == 'Interval' %}
@@ -30,3 +32,7 @@ var data{{ id }} = new google.visualization.DataTable({{ data | raw }});
     {% endfor %}
 {% endif %}
 chart{{ id }}.draw(data{{ id }}, {{ config | json_encode | raw }});
+
+};
+
+google.charts.setOnLoadCallback(drawGoogleChart_{{ id }});

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -4,16 +4,15 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>{% block title %}Demo Bundle{% endblock %}</title>
         <link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />
-        <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+        <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
         <script type="text/javascript">
-            google.load("visualization", "1", {packages:["corechart", 'table', 'treemap', 'gauge']});
-            google.load('jquery', '1.6.0');
+            google.charts.load('current', {packages:["corechart", 'table', 'treemap', 'gauge']});
         </script>
     </head>
     <body>
             
             <header>
-                <h1>GChartBundle Demo</h2>
+                <h1>GChartBundle Demo</h1>
             </header>
 
             {% for msg in app.session.flashbag.get('notice') %}
@@ -28,8 +27,5 @@
                 {% block content %}
                 {% endblock %}
             </div>
-
-
-        </div>
     </body>
 </html>


### PR DESCRIPTION
The Google Charts loader is using the old loader, and causes a number of errors in console, e.g.:

> A parser-blocking, cross site (i.e. different eTLD+1) script, https://www.google.com/uds/api/visualization/1.0/40ff64b1d9d6b3213524485974f36cc0/format+en,default+en,ui+en,table+en,gauge+en,annotatedtimeline+en,controls+en,corechart+en.I.js, is invoked via document.write. The network request for this script MAY be blocked by the browser in this or a future page load due to poor network connectivity. If blocked in this page load, it will be confirmed in a subsequent console message. See https://www.chromestatus.com/feature/5718547946799104 for more details.

The new Google Charts loader does not do this, and so we should upgrade. The new loader requires a callback function to load the chart, and so therefore JQuery can also be removed making the demos a bit faster :)

I've also fixed a couple of minor typos and updated some links in the README to make that better as well.

P.s. we've been using this bundle for a long time now. It's been really great to us, and I wanted to say thanks to everyone for working on it!!