### PR TITLE
Support dates in config

### DIFF
--- a/Resources/views/chart/visualizationChart.html.twig
+++ b/Resources/views/chart/visualizationChart.html.twig
@@ -32,7 +32,7 @@ var data{{ id }} = new google.visualization.DataTable({{ data | raw }});
     {% endfor %}
 {% endif %}
 
-chart{{ id }}.draw(data{{ id }}, {{ config | json_encode | replace({"\"new Date[[[": 'new Date(', "new Date\"": ""}) | replace({"]]]\"": ')', "]]]\"": ")"} | raw }});
+chart{{ id }}.draw(data{{ id }}, {{ config | json_encode | replace({"\"new Date[[[": 'new Date(', "new Date\"": ""}) | replace({"]]]\"": ')', "]]]\"": ")"}) | raw }});
 
 };
 

--- a/Resources/views/chart/visualizationChart.html.twig
+++ b/Resources/views/chart/visualizationChart.html.twig
@@ -31,7 +31,8 @@ var data{{ id }} = new google.visualization.DataTable({{ data | raw }});
         google.visualization.events.addListener(chart{{ id }}, '{{ event.eventName }}', {{ event.callbackFunc }});
     {% endfor %}
 {% endif %}
-chart{{ id }}.draw(data{{ id }}, {{ config | json_encode | raw }});
+
+chart{{ id }}.draw(data{{ id }}, {{ config | json_encode | replace({"\"new Date[[[": 'new Date(', "new Date\"": ""}) | replace({"]]]\"": ')', "]]]\"": ")"} | raw }});
 
 };
 


### PR DESCRIPTION
We've discovered a case where we want to use the date replacement in the config, specifying a minValue and a maxValue.

This PR adds that functionality - repeating the same JSON replace magic in the config in the same way as it is done elsewhere. 