### PR TITLE
Changed to work on Symfony 7.4

### DIFF
--- a/DependencyInjection/SaadTaziGChartExtension.php
+++ b/DependencyInjection/SaadTaziGChartExtension.php
@@ -2,7 +2,7 @@
 
 namespace SaadTazi\GChartBundle\DependencyInjection;
 
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -12,11 +12,10 @@ use Symfony\Component\Config\FileLocator;
 class SaadTaziGChartExtension extends Extension
 {
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__.'/../Resources/config')));
         $loader->load('g_chart.xml');
-        
     }
 
 

--- a/Twig/GChartExtension.php
+++ b/Twig/GChartExtension.php
@@ -12,6 +12,8 @@ use Twig\Environment;
  */
 class GChartExtension extends AbstractExtension {
 
+    protected array $resources;
+    
     /**
      * @param array $resources a list of resources (see Resources/g_chart.xml)
      */

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "5.*|6.*"
+        "symfony/framework-bundle": "5.*|6.*|7.*"
  	},
     "autoload": {
         "psr-0": { "SaadTazi\\GChartBundle": "" }


### PR DESCRIPTION
- Changed to work on Symfony 7.

Note:
There is one deprecation left. g_chart.xml, has to be changed to php o yaml if you are planning to migrate to Symfony 8. But works fine on Symfony 7.4.